### PR TITLE
AAP-2844 Add collections and content signing info

### DIFF
--- a/downstream/assemblies/hub/assembly-collections-and-content-signing-in-pah.adoc
+++ b/downstream/assemblies/hub/assembly-collections-and-content-signing-in-pah.adoc
@@ -2,7 +2,9 @@
 
 = Collections and content signing in {PrivateHubName}
 
-As an automation creator, you can configure your private automation hub to successfully sign and publish your own content collections while still maintaining access to Red Hat Certified Collections available through your Ansible Automation Platform subscription or community collections available through Ansible Galaxy. In addition, you can configure Ansible-Galaxy CLI to verify collections to ensure that your collections are approved by your organization and have not been changed after it was uploaded to your automation hub.
+As an automation administrator for your organization, you can configure private automation hub for signing and publishing Ansible content collections from different groups within your organization.
+
+For additional security, automation creators can configure Ansible-Galaxy CLI to verify these collections to ensure they have not been changed after they were uploaded to automation hub.
 
 
 include::automation-hub/proc-configure-content-signing-on-pah.adoc[leveloffset=+1]

--- a/downstream/assemblies/hub/assembly-collections-and-content-signing-in-pah.adoc
+++ b/downstream/assemblies/hub/assembly-collections-and-content-signing-in-pah.adoc
@@ -5,8 +5,8 @@
 As an automation creator, you can configure your private automation hub to successfully sign and publish your own content collections while still maintaining access to Red Hat Certified Collections available through your Ansible Automation Platform subscription or community collections available through Ansible Galaxy. In addition, you can configure Ansible-Galaxy CLI to verify collections to ensure that your collections are approved by your organization and have not been changed after it was uploaded to your automation hub.
 
 
-include::modules/proc-configure-content-signing-on-pah.adoc[leveloffset=+2]
+include::automation-hub/proc-configure-content-signing-on-pah.adoc[leveloffset=+2]
 
-include::modules/proc-using-content-signing-services-in-pah.adoc[leveloffset=+2]
+include::automation-hub/proc-using-content-signing-services-in-pah.adoc[leveloffset=+2]
 
-include::modules/proc-configure-ansible-galaxy-cli-verify.adoc[leveloffset=2]
+include::automation-hub/proc-configure-ansible-galaxy-cli-verify.adoc[leveloffset=2]

--- a/downstream/assemblies/hub/assembly-collections-and-content-signing-in-pah.adoc
+++ b/downstream/assemblies/hub/assembly-collections-and-content-signing-in-pah.adoc
@@ -2,9 +2,9 @@
 
 = Collections and content signing in {PrivateHubName}
 
-As an automation administrator for your organization, you can configure private automation hub for signing and publishing Ansible content collections from different groups within your organization.
+As an automation administrator for your organization, you can configure {PrivateHubName} for signing and publishing Ansible content collections from different groups within your organization.
 
-For additional security, automation creators can configure Ansible-Galaxy CLI to verify these collections to ensure they have not been changed after they were uploaded to automation hub.
+For additional security, automation creators can configure Ansible-Galaxy CLI to verify these collections to ensure they have not been changed after they were uploaded to {HubName}.
 
 
 include::automation-hub/proc-configure-content-signing-on-pah.adoc[leveloffset=+1]

--- a/downstream/assemblies/hub/assembly-collections-and-content-signing-in-pah.adoc
+++ b/downstream/assemblies/hub/assembly-collections-and-content-signing-in-pah.adoc
@@ -5,8 +5,8 @@
 As an automation creator, you can configure your private automation hub to successfully sign and publish your own content collections while still maintaining access to Red Hat Certified Collections available through your Ansible Automation Platform subscription or community collections available through Ansible Galaxy. In addition, you can configure Ansible-Galaxy CLI to verify collections to ensure that your collections are approved by your organization and have not been changed after it was uploaded to your automation hub.
 
 
-include::automation-hub/proc-configure-content-signing-on-pah.adoc[leveloffset=+2]
+include::automation-hub/proc-configure-content-signing-on-pah.adoc[leveloffset=+1]
 
-include::automation-hub/proc-using-content-signing-services-in-pah.adoc[leveloffset=+2]
+include::automation-hub/proc-using-content-signing-services-in-pah.adoc[leveloffset=+1]
 
-include::automation-hub/proc-configure-ansible-galaxy-cli-verify.adoc[leveloffset=2]
+include::automation-hub/proc-configure-ansible-galaxy-cli-verify.adoc[leveloffset=1]

--- a/downstream/assemblies/hub/assembly-collections-and-content-signing-in-pah.adoc
+++ b/downstream/assemblies/hub/assembly-collections-and-content-signing-in-pah.adoc
@@ -1,0 +1,12 @@
+[id="assembly-collections-and-content-signing-in-pah"]
+
+= Collections and content signing in {PrivateHubName}
+
+As an automation creator, you can configure your private automation hub to successfully sign and publish your own content collections while still maintaining access to Red Hat Certified Collections available through your Ansible Automation Platform subscription or community collections available through Ansible Galaxy. In addition, you can configure Ansible-Galaxy CLI to verify collections to ensure that your collections are approved by your organization and have not been changed after it was uploaded to your automation hub.
+
+
+include::modules/proc-configure-content-signing-on-pah.adoc[leveloffset=+2]
+
+include::modules/proc-using-content-signing-services-in-pah.adoc[leveloffset=+2]
+
+include::modules/proc-configure-ansible-galaxy-cli-verify.adoc[leveloffset=2]

--- a/downstream/assemblies/hub/assembly-collections-and-content-signing-in-pah.adoc
+++ b/downstream/assemblies/hub/assembly-collections-and-content-signing-in-pah.adoc
@@ -9,4 +9,4 @@ include::automation-hub/proc-configure-content-signing-on-pah.adoc[leveloffset=+
 
 include::automation-hub/proc-using-content-signing-services-in-pah.adoc[leveloffset=+1]
 
-include::automation-hub/proc-configure-ansible-galaxy-cli-verify.adoc[leveloffset=1]
+include::automation-hub/proc-configure-ansible-galaxy-cli-verify.adoc[leveloffset=+1]

--- a/downstream/modules/automation-hub/proc-configure-ansible-galaxy-cli-verify.adoc
+++ b/downstream/modules/automation-hub/proc-configure-ansible-galaxy-cli-verify.adoc
@@ -5,7 +5,8 @@
 You can configure Ansible-Galaxy CLI to verify collections.
 This assures that collections you download are approved by your organization and have not been changed after they were uploaded to {HubName}.
 
-If a collection has been signed by {HubName}, the server provides ASCII armored, GPG-detached signatures to verify the authenticity of MANIFEST.json before using it to verify the collection’s contents. You must opt into signature verification by link:https://docs.ansible.com/ansible/devel/reference_appendices/config.html#galaxy-gpg-keyring[configuring a keyring] for `ansible-galaxy` or providing the path with the `--keyring` option.
+If a collection has been signed by {HubName}, the server provides ASCII armored, GPG-detached signatures to verify the authenticity of MANIFEST.json before using it to verify the collection’s contents.
+You must opt into signature verification by link:https://docs.ansible.com/ansible/devel/reference_appendices/config.html#galaxy-gpg-keyring[configuring a keyring] for `ansible-galaxy` or providing the path with the `--keyring` option.
 
 .Prerequisites
 

--- a/downstream/modules/automation-hub/proc-configure-ansible-galaxy-cli-verify.adoc
+++ b/downstream/modules/automation-hub/proc-configure-ansible-galaxy-cli-verify.adoc
@@ -2,7 +2,8 @@
 
 = Configuring Ansible-Galaxy CLI to verify collections
 
-You can configure Ansible-Galaxy CLI to verify collections. This assures that collections you download are approved by your organization and have not been changed after they were uploaded to {HubName}.
+You can configure Ansible-Galaxy CLI to verify collections.
+This assures that collections you download are approved by your organization and have not been changed after they were uploaded to {HubName}.
 
 If a collection has been signed by {HubName}, the server provides ASCII armored, GPG-detached signatures to verify the authenticity of MANIFEST.json before using it to verify the collection’s contents. You must opt into signature verification by link:https://docs.ansible.com/ansible/devel/reference_appendices/config.html#galaxy-gpg-keyring[configuring a keyring] for `ansible-galaxy` or providing the path with the `--keyring` option.
 

--- a/downstream/modules/automation-hub/proc-configure-ansible-galaxy-cli-verify.adoc
+++ b/downstream/modules/automation-hub/proc-configure-ansible-galaxy-cli-verify.adoc
@@ -34,7 +34,7 @@ ansible-galaxy collection install namespace.collection
 --signature file:///path/to/local/detached_signature.asc --keyring ~/.ansible/pubring.kbx
 ----
 You can use this option multiple times to provide multiple signatures.
-. Confirm that the collections in a requirements file lists any additional signature sources following the collection’s signatures key, as in the following example.
+. Confirm that the collections in a requirements file list any additional signature sources following the collection’s signatures key, as in the following example.
 +
 [source,yaml]
 ----

--- a/downstream/modules/automation-hub/proc-configure-ansible-galaxy-cli-verify.adoc
+++ b/downstream/modules/automation-hub/proc-configure-ansible-galaxy-cli-verify.adoc
@@ -4,14 +4,14 @@
 
 You can configure Ansible-Galaxy CLI to verify collections. This assures that collections you download are approved by your organization and have not been changed after it was uploaded to  {HubName}.
 
+If a collection has been signed by the Galaxy server, the server provides ASCII armored, detached signatures to verify the authenticity of the MANIFEST.json before using it to verify the collection’s contents. You must opt into signature verification by link:https://docs.ansible.com/ansible/devel/reference_appendices/config.html#galaxy-gpg-keyring[configuring a keyring] for `ansible-galaxy` or providing the path with the `--keyring` option.
+
 .Prerequisites
 
 * Signed and certified collections have been published to {HubName}.
 * Public key for verification has been added to the local system keyring.
 
 .Procedure
-
-If a collection has been signed by the Galaxy server, the server provides ASCII armored, detached signatures to verify the authenticity of the MANIFEST.json before using it to verify the collection’s contents. You must opt into signature verification by link:https://docs.ansible.com/ansible/devel/reference_appendices/config.html#galaxy-gpg-keyring[configuring a keyring] for `ansible-galaxy` or providing the path with the `--keyring` option.
 
 . To import a public key into a keyring for use with `ansible-galaxy`, run the following command.
 +
@@ -46,5 +46,6 @@ collections:
 
 ansible-galaxy collection verify -r requirements.yml --keyring ~/.ansible/pubring.kbx
 ----
+
 When you install a collection from a Galaxy server, the signatures provided by the server are saved along with the installed collections to verify the collection’s authenticity.
 . (Optional) If you need to verify the internal consistency of your collection again without querying the Galaxy server, run the same command you used previously using the `--offline` option.

--- a/downstream/modules/automation-hub/proc-configure-ansible-galaxy-cli-verify.adoc
+++ b/downstream/modules/automation-hub/proc-configure-ansible-galaxy-cli-verify.adoc
@@ -1,0 +1,50 @@
+[id="proc-configure-ansible-galaxy-cli-verify_{context}"]
+
+= Configuring Ansible-Galaxy CLI to verify collections
+
+You can configure Ansible-Galaxy CLI to verify collections. This assures that collections you download are approved by your organization and have not been changed after it was uploaded to  {HubName}.
+
+.Prerequisites
+
+* Signed and certified collections have been published to {HubName}.
+* Public key for verification has been added to the local system keyring.
+
+.Procedure
+
+If a collection has been signed by the Galaxy server, the server provides ASCII armored, detached signatures to verify the authenticity of the MANIFEST.json before using it to verify the collection’s contents. You must opt into signature verification by link:https://docs.ansible.com/ansible/devel/reference_appendices/config.html#galaxy-gpg-keyring[configuring a keyring] for `ansible-galaxy` or providing the path with the `--keyring` option.
+
+. To import a public key into a keyring for use with `ansible-galaxy`, run the following command.
++
+----
+gpg --import --no-default-keyring --keyring ~/.ansible/pubring.kbx my-public-key.asc
+----
++
+[NOTE]
+====
+In addition to any signatures provided by the Galaxy server, signature sources can also be provided in the requirements file and on the command line. Signature sources should be URIs.
+====
++
+. Use the --signature option to verify collection name(s) provided on the CLI with an additional signature.
++
+----
+ansible-galaxy collection install namespace.collection
+--signature https://examplehost.com/detached_signature.asc
+--signature file:///path/to/local/detached_signature.asc --keyring ~/.ansible/pubring.kbx
+----
+You can use this option multiple times to provide multiple signatures.
+. Confirm that the collections in a requirements file lists any additional signature sources following the collection’s signatures key, as in the following example.
++
+[source,yaml]
+----
+# requirements.yml
+collections:
+  - name: ns.coll
+    version: 1.0.0
+    signatures:
+      - https://examplehost.com/detached_signature.asc
+      - file:///path/to/local/detached_signature.asc
+
+ansible-galaxy collection verify -r requirements.yml --keyring ~/.ansible/pubring.kbx
+----
+When you install a collection from a Galaxy server, the signatures provided by the server are saved along with the installed collections to verify the collection’s authenticity.
+. (Optional) If you need to verify the internal consistency of your collection again without querying the Galaxy server, run the same command you used previously using the `--offline` option.

--- a/downstream/modules/automation-hub/proc-configure-ansible-galaxy-cli-verify.adoc
+++ b/downstream/modules/automation-hub/proc-configure-ansible-galaxy-cli-verify.adoc
@@ -4,7 +4,7 @@
 
 You can configure Ansible-Galaxy CLI to verify collections. This assures that collections you download are approved by your organization and have not been changed after it was uploaded to  {HubName}.
 
-If a collection has been signed by the Galaxy server, the server provides ASCII armored, detached signatures to verify the authenticity of the MANIFEST.json before using it to verify the collection’s contents. You must opt into signature verification by link:https://docs.ansible.com/ansible/devel/reference_appendices/config.html#galaxy-gpg-keyring[configuring a keyring] for `ansible-galaxy` or providing the path with the `--keyring` option.
+If a collection has been signed by the Galaxy server, the server provides ASCII armored, GPG-detached signatures to verify the authenticity of the MANIFEST.json before using it to verify the collection’s contents. You must opt into signature verification by link:https://docs.ansible.com/ansible/devel/reference_appendices/config.html#galaxy-gpg-keyring[configuring a keyring] for `ansible-galaxy` or providing the path with the `--keyring` option.
 
 .Prerequisites
 
@@ -14,7 +14,7 @@ If a collection has been signed by the Galaxy server, the server provides ASCII 
 
 .Procedure
 
-. To import a public key into a keyring for use with `ansible-galaxy`, run the following command.
+. To import a public key into a non-default keyring for use with `ansible-galaxy`, run the following command.
 +
 ----
 gpg --import --no-default-keyring --keyring ~/.ansible/pubring.kbx my-public-key.asc

--- a/downstream/modules/automation-hub/proc-configure-ansible-galaxy-cli-verify.adoc
+++ b/downstream/modules/automation-hub/proc-configure-ansible-galaxy-cli-verify.adoc
@@ -1,4 +1,4 @@
-[id="proc-configure-ansible-galaxy-cli-verify_{context}"]
+[id="proc-configure-ansible-galaxy-cli-verify"]
 
 = Configuring Ansible-Galaxy CLI to verify collections
 

--- a/downstream/modules/automation-hub/proc-configure-ansible-galaxy-cli-verify.adoc
+++ b/downstream/modules/automation-hub/proc-configure-ansible-galaxy-cli-verify.adoc
@@ -4,7 +4,7 @@
 
 You can configure Ansible-Galaxy CLI to verify collections. This assures that collections you download are approved by your organization and have not been changed after it was uploaded to {HubName}.
 
-If a collection has been signed by the Galaxy server, the server provides ASCII armored, GPG-detached signatures to verify the authenticity of the MANIFEST.json before using it to verify the collection’s contents. You must opt into signature verification by link:https://docs.ansible.com/ansible/devel/reference_appendices/config.html#galaxy-gpg-keyring[configuring a keyring] for `ansible-galaxy` or providing the path with the `--keyring` option.
+If a collection has been signed by {HubName}, the server provides ASCII armored, GPG-detached signatures to verify the authenticity of the MANIFEST.json before using it to verify the collection’s contents. You must opt into signature verification by link:https://docs.ansible.com/ansible/devel/reference_appendices/config.html#galaxy-gpg-keyring[configuring a keyring] for `ansible-galaxy` or providing the path with the `--keyring` option.
 
 .Prerequisites
 
@@ -22,7 +22,7 @@ gpg --import --no-default-keyring --keyring ~/.ansible/pubring.kbx my-public-key
 +
 [NOTE]
 ====
-In addition to any signatures provided by the Galaxy server, signature sources can also be provided in the requirements file and on the command line. Signature sources should be URIs.
+In addition to any signatures provided by the {HubName}, signature sources can also be provided in the requirements file and on the command line. Signature sources should be URIs.
 ====
 +
 . Use the `--signature` option to verify the collection name provided on the CLI with an additional signature.
@@ -48,5 +48,5 @@ collections:
 ansible-galaxy collection verify -r requirements.yml --keyring ~/.ansible/pubring.kbx
 ----
 +
-When you install a collection from a Galaxy server, the signatures provided by the server are saved along with the installed collections to verify the collection’s authenticity.
+When you install a collection from {HubName}, the signatures provided by the server are saved along with the installed collections to verify the collection’s authenticity.
 . (Optional) If you need to verify the internal consistency of your collection again without querying the Galaxy server, run the same command you used previously using the `--offline` option.

--- a/downstream/modules/automation-hub/proc-configure-ansible-galaxy-cli-verify.adoc
+++ b/downstream/modules/automation-hub/proc-configure-ansible-galaxy-cli-verify.adoc
@@ -8,7 +8,8 @@ If a collection has been signed by the Galaxy server, the server provides ASCII 
 
 .Prerequisites
 
-* Signed and certified collections have been published to {HubName}.
+* Signed collections are available in {HubName} to verify signature.
+* Certified collections can be signed by approved roles within your organization.
 * Public key for verification has been added to the local system keyring.
 
 .Procedure
@@ -24,7 +25,7 @@ gpg --import --no-default-keyring --keyring ~/.ansible/pubring.kbx my-public-key
 In addition to any signatures provided by the Galaxy server, signature sources can also be provided in the requirements file and on the command line. Signature sources should be URIs.
 ====
 +
-. Use the --signature option to verify collection name(s) provided on the CLI with an additional signature.
+. Use the `--signature` option to verify the collection name provided on the CLI with an additional signature.
 +
 ----
 ansible-galaxy collection install namespace.collection

--- a/downstream/modules/automation-hub/proc-configure-ansible-galaxy-cli-verify.adoc
+++ b/downstream/modules/automation-hub/proc-configure-ansible-galaxy-cli-verify.adoc
@@ -49,4 +49,4 @@ ansible-galaxy collection verify -r requirements.yml --keyring ~/.ansible/pubrin
 ----
 +
 When you install a collection from {HubName}, the signatures provided by the server are saved along with the installed collections to verify the collection’s authenticity.
-. (Optional) If you need to verify the internal consistency of your collection again without querying the Galaxy server, run the same command you used previously using the `--offline` option.
+. (Optional) If you need to verify the internal consistency of your collection again without querying the {Galaxy} server, run the same command you used previously using the `--offline` option.

--- a/downstream/modules/automation-hub/proc-configure-ansible-galaxy-cli-verify.adoc
+++ b/downstream/modules/automation-hub/proc-configure-ansible-galaxy-cli-verify.adoc
@@ -46,6 +46,6 @@ collections:
 
 ansible-galaxy collection verify -r requirements.yml --keyring ~/.ansible/pubring.kbx
 ----
-
++
 When you install a collection from a Galaxy server, the signatures provided by the server are saved along with the installed collections to verify the collection’s authenticity.
 . (Optional) If you need to verify the internal consistency of your collection again without querying the Galaxy server, run the same command you used previously using the `--offline` option.

--- a/downstream/modules/automation-hub/proc-configure-ansible-galaxy-cli-verify.adoc
+++ b/downstream/modules/automation-hub/proc-configure-ansible-galaxy-cli-verify.adoc
@@ -2,7 +2,7 @@
 
 = Configuring Ansible-Galaxy CLI to verify collections
 
-You can configure Ansible-Galaxy CLI to verify collections. This assures that collections you download are approved by your organization and have not been changed after it was uploaded to  {HubName}.
+You can configure Ansible-Galaxy CLI to verify collections. This assures that collections you download are approved by your organization and have not been changed after it was uploaded to {HubName}.
 
 If a collection has been signed by the Galaxy server, the server provides ASCII armored, GPG-detached signatures to verify the authenticity of the MANIFEST.json before using it to verify the collection’s contents. You must opt into signature verification by link:https://docs.ansible.com/ansible/devel/reference_appendices/config.html#galaxy-gpg-keyring[configuring a keyring] for `ansible-galaxy` or providing the path with the `--keyring` option.
 

--- a/downstream/modules/automation-hub/proc-configure-ansible-galaxy-cli-verify.adoc
+++ b/downstream/modules/automation-hub/proc-configure-ansible-galaxy-cli-verify.adoc
@@ -2,9 +2,9 @@
 
 = Configuring Ansible-Galaxy CLI to verify collections
 
-You can configure Ansible-Galaxy CLI to verify collections. This assures that collections you download are approved by your organization and have not been changed after it was uploaded to {HubName}.
+You can configure Ansible-Galaxy CLI to verify collections. This assures that collections you download are approved by your organization and have not been changed after they were uploaded to {HubName}.
 
-If a collection has been signed by {HubName}, the server provides ASCII armored, GPG-detached signatures to verify the authenticity of the MANIFEST.json before using it to verify the collection’s contents. You must opt into signature verification by link:https://docs.ansible.com/ansible/devel/reference_appendices/config.html#galaxy-gpg-keyring[configuring a keyring] for `ansible-galaxy` or providing the path with the `--keyring` option.
+If a collection has been signed by {HubName}, the server provides ASCII armored, GPG-detached signatures to verify the authenticity of MANIFEST.json before using it to verify the collection’s contents. You must opt into signature verification by link:https://docs.ansible.com/ansible/devel/reference_appendices/config.html#galaxy-gpg-keyring[configuring a keyring] for `ansible-galaxy` or providing the path with the `--keyring` option.
 
 .Prerequisites
 

--- a/downstream/modules/automation-hub/proc-configure-content-signing-on-pah.adoc
+++ b/downstream/modules/automation-hub/proc-configure-content-signing-on-pah.adoc
@@ -57,15 +57,15 @@ After you deploy a {PrivateHubName} with signing enabled to your {PlatformNameSh
 
 . Review the output from the installer that begins with `automationhub_*`.
 +
-[source,highlight=6;7]
+[source,highlight=67-68]
 ----
 [all:vars]
 .
 .
 .
 automationhub_create_default_collection_signing_service = True
-*automationhub_auto_sign_collections = True*
-*automationhub_require_content_approval = True*
+automationhub_auto_sign_collections = True
+automationhub_require_content_approval = True
 automationhub_collection_signing_service_key = /abs/path/to/galaxy_signing_service.gpg
 automationhub_collection_signing_service_script = /abs/path/to/collection_signing.sh
 ----

--- a/downstream/modules/automation-hub/proc-configure-content-signing-on-pah.adoc
+++ b/downstream/modules/automation-hub/proc-configure-content-signing-on-pah.adoc
@@ -1,4 +1,4 @@
-[id="proc-configure-content-signing-on-pah_{context}"]
+[id="proc-configure-content-signing-on-pah"]
 
 = Configuring content signing on private automation hub
 

--- a/downstream/modules/automation-hub/proc-configure-content-signing-on-pah.adoc
+++ b/downstream/modules/automation-hub/proc-configure-content-signing-on-pah.adoc
@@ -1,0 +1,73 @@
+[id="proc-configure-content-signing-on-pah_{context}"]
+
+= Configuring content signing on private automation hub
+
+To successfully sign and publish {CertifiedName}, you must configure {PrivateHubName} for signing.
+
+.Prerequisites
+
+* Your GnuPG key pairs have been securely set up and managed by your organization.
+* Your public/private key pair has proper access for configuring content signing on {PrivateHubName}.
+
+.Procedure
+
+. Create a signing script that only accepts a filename.
++
+[NOTE]
+====
+This script will act as the signing service and must generate an ascii-armored detached `gpg` signature for that file using the key specified through the `PULP_SIGNING_KEY_FINGERPRINT` environment variable.
+====
++
+The script should then print out a JSON structure with the following format.
++
+----
+{"file": "filename", "signature": "filename.asc"}
+----
++
+All the file names are relative paths inside the current working directory. The filename must remain the same for the detached signature, as shown.
++
+The following example shows a script that produces signatures for content:
++
+[source,shell]
+----
+#!/usr/bin/env bash
+
+FILE_PATH=$1
+SIGNATURE_PATH="$1.asc"
+
+ADMIN_ID="$PULP_SIGNING_KEY_FINGERPRINT"
+PASSWORD="password"
+
+# Create a detached signature
+gpg --quiet --batch --pinentry-mode loopback --yes --passphrase \
+   $PASSWORD --homedir ~/.gnupg/ --detach-sign --default-key $ADMIN_ID \
+   --armor --output $SIGNATURE_PATH $FILE_PATH
+
+# Check the exit status
+STATUS=$?
+if [ $STATUS -eq 0 ]; then
+   echo {\"file\": \"$FILE_PATH\", \"signature\": \"$SIGNATURE_PATH\"}
+else
+   exit $STATUS
+fi
+----
+
++
+After you deploy a {PrivateHubName} with signing enabled to your {PlatformNameShort} cluster, new UI additions display when you interact with collections.
+
+. Review the output from the installer that begins with `automationhub_*``.
++
+[source,highlight=6-8]
+----
+[all:vars]
+.
+.
+.
+automationhub_create_default_collection_signing_service = True
+automationhub_auto_sign_collections = True
+automationhub_require_content_approval = True
+automationhub_collection_signing_service_key = /abs/path/to/galaxy_signing_service.gpg
+automationhub_collection_signing_service_script = /abs/path/to/collection_signing.sh
+----
++
+The two new keys in the deployment highlighted in the previous example demonstrate that the collections must be signed and require approval after they are uploaded to {PrivateHubName}.

--- a/downstream/modules/automation-hub/proc-configure-content-signing-on-pah.adoc
+++ b/downstream/modules/automation-hub/proc-configure-content-signing-on-pah.adoc
@@ -57,7 +57,7 @@ After you deploy a {PrivateHubName} with signing enabled to your {PlatformNameSh
 
 . Review the output from the installer that begins with `automationhub_*``.
 +
-[source,highlight=6-8]
+[source,highlight=6;7]
 ----
 [all:vars]
 .

--- a/downstream/modules/automation-hub/proc-configure-content-signing-on-pah.adoc
+++ b/downstream/modules/automation-hub/proc-configure-content-signing-on-pah.adoc
@@ -24,7 +24,7 @@ The script should then print out a JSON structure with the following format.
 {"file": "filename", "signature": "filename.asc"}
 ----
 +
-All the file names are relative paths inside the current working directory. The filename must remain the same for the detached signature, as shown.
+All the file names are relative paths inside the current working directory. The file name must remain the same for the detached signature, as shown.
 +
 The following example shows a script that produces signatures for content:
 +

--- a/downstream/modules/automation-hub/proc-configure-content-signing-on-pah.adoc
+++ b/downstream/modules/automation-hub/proc-configure-content-signing-on-pah.adoc
@@ -64,8 +64,8 @@ After you deploy a {PrivateHubName} with signing enabled to your {PlatformNameSh
 .
 .
 automationhub_create_default_collection_signing_service = True
-automationhub_auto_sign_collections = True
-automationhub_require_content_approval = True
+*automationhub_auto_sign_collections = True*
+*automationhub_require_content_approval = True*
 automationhub_collection_signing_service_key = /abs/path/to/galaxy_signing_service.gpg
 automationhub_collection_signing_service_script = /abs/path/to/collection_signing.sh
 ----

--- a/downstream/modules/automation-hub/proc-configure-content-signing-on-pah.adoc
+++ b/downstream/modules/automation-hub/proc-configure-content-signing-on-pah.adoc
@@ -70,4 +70,4 @@ automationhub_collection_signing_service_key = /abs/path/to/galaxy_signing_servi
 automationhub_collection_signing_service_script = /abs/path/to/collection_signing.sh
 ----
 +
-The two new keys in the deployment highlighted in the previous example demonstrate that the collections must be signed and require approval after they are uploaded to {PrivateHubName}.
+The two new keys (*automationhub_auto_sign_collections* and *automationhub_require_content_approval*) in the previous example demonstrate that the collections must be signed and require approval after they are uploaded to {PrivateHubName}.

--- a/downstream/modules/automation-hub/proc-configure-content-signing-on-pah.adoc
+++ b/downstream/modules/automation-hub/proc-configure-content-signing-on-pah.adoc
@@ -18,7 +18,7 @@ To successfully sign and publish {CertifiedName}, you must configure {PrivateHub
 This script will act as the signing service and must generate an ascii-armored detached `gpg` signature for that file using the key specified through the `PULP_SIGNING_KEY_FINGERPRINT` environment variable.
 ====
 +
-The script should then print out a JSON structure with the following format.
+The script then prints out a JSON structure with the following format.
 +
 ----
 {"file": "filename", "signature": "filename.asc"}
@@ -70,4 +70,4 @@ automationhub_collection_signing_service_key = /abs/path/to/galaxy_signing_servi
 automationhub_collection_signing_service_script = /abs/path/to/collection_signing.sh
 ----
 +
-The two new keys (*automationhub_auto_sign_collections* and *automationhub_require_content_approval*) in the previous example demonstrate that the collections must be signed and require approval after they are uploaded to {PrivateHubName}.
+The two new keys (*automationhub_auto_sign_collections* and *automationhub_require_content_approval*) indicate that the collections must be signed and require approval after they are uploaded to {PrivateHubName}.

--- a/downstream/modules/automation-hub/proc-configure-content-signing-on-pah.adoc
+++ b/downstream/modules/automation-hub/proc-configure-content-signing-on-pah.adoc
@@ -55,7 +55,7 @@ fi
 +
 After you deploy a {PrivateHubName} with signing enabled to your {PlatformNameShort} cluster, new UI additions display when you interact with collections.
 
-. Review the output from the installer that begins with `automationhub_*``.
+. Review the output from the installer that begins with `automationhub_*`.
 +
 [source,highlight=6;7]
 ----

--- a/downstream/modules/automation-hub/proc-configure-content-signing-on-pah.adoc
+++ b/downstream/modules/automation-hub/proc-configure-content-signing-on-pah.adoc
@@ -55,7 +55,7 @@ fi
 +
 After you deploy a {PrivateHubName} with signing enabled to your {PlatformNameShort} cluster, new UI additions display when you interact with collections.
 
-. Review the output from the installer that begins with `automationhub_*`.
+. Review the AAP installer inventory file for options that begins with `automationhub_*`.
 +
 [source,highlight=67-68]
 ----

--- a/downstream/modules/automation-hub/proc-using-content-signing-services-in-pah.adoc
+++ b/downstream/modules/automation-hub/proc-using-content-signing-services-in-pah.adoc
@@ -18,6 +18,6 @@ Content signing on {PrivateHubName} provides solutions for the following scenari
 . In the left navigation, click *Collections > Approval*.
 The Approval dashboard is displayed with a list of collections.
 
-. Click the *Sign and approve* button for each collection you want to prefer to sign.
+. Click the *Sign and approve* button for each collection you want to sign.
 
 . Verify that the collections you signed and approved manually are displayed in the Collections tab.

--- a/downstream/modules/automation-hub/proc-using-content-signing-services-in-pah.adoc
+++ b/downstream/modules/automation-hub/proc-using-content-signing-services-in-pah.adoc
@@ -1,0 +1,35 @@
+[id="proc-using-content-signing-services-in-pah_{context}"]
+
+= Using content signing services in private automation hub
+
+After you have configured content signing on your {PrivateHubName}, you can manually sign a new collection or replace an existing signature with a new one so that users who want to download a specific collection have the assurance that the collection is intended for them and has not been modified after certification.
+
+Content signing on {PrivateHubName} provides solutions for the following scenarios:
+
+* Your system does not have automatic signing configured and you must use a manual signing process to sign collections.
+* The current signatures on the automatically configured collections are corrupted and must be replaced with new signatures.
+* Additional signatures are required for previously signed content.
+* You want to rotate signatures on your collections.
+
+.Procedure
+
+. In the `automationhub-terminal`, run the following command to publish your collections:
++
+----
+ansible-galaxy collection publish <ansible-test_collection-1.0.0.tar.gz> -c
+----
++
+[NOTE]
+====
+The `-c` option is used to ignore SSL certificate errors.
+====
+. Log in to your {PrivateHubName} instance in the {HubName} UI.
+
+. Use an unnumbered bullet (*) if the procedure includes only one step.
+
+. In the left navigation, click *Collections > Approval*.
+The Approval dashboard is displayed with a list of collections.
+
+. Click the *Sign and approve* button for each collection you want to prefer to sign.
+
+. Verify that the collections you signed and approved manually are displayed in the Collections tab.

--- a/downstream/modules/automation-hub/proc-using-content-signing-services-in-pah.adoc
+++ b/downstream/modules/automation-hub/proc-using-content-signing-services-in-pah.adoc
@@ -13,19 +13,7 @@ Content signing on {PrivateHubName} provides solutions for the following scenari
 
 .Procedure
 
-. In the `automationhub-terminal`, run the following command to publish your collections:
-+
-----
-ansible-galaxy collection publish <ansible-test_collection-1.0.0.tar.gz> -c
-----
-+
-[NOTE]
-====
-The `-c` option is used to ignore SSL certificate errors.
-====
 . Log in to your {PrivateHubName} instance in the {HubName} UI.
-
-. Use an unnumbered bullet (*) if the procedure includes only one step.
 
 . In the left navigation, click *Collections > Approval*.
 The Approval dashboard is displayed with a list of collections.

--- a/downstream/modules/automation-hub/proc-using-content-signing-services-in-pah.adoc
+++ b/downstream/modules/automation-hub/proc-using-content-signing-services-in-pah.adoc
@@ -1,4 +1,4 @@
-[id="proc-using-content-signing-services-in-pah_{context}"]
+[id="proc-using-content-signing-services-in-pah"]
 
 = Using content signing services in private automation hub
 

--- a/downstream/modules/automation-hub/proc-using-content-signing-services-in-pah.adoc
+++ b/downstream/modules/automation-hub/proc-using-content-signing-services-in-pah.adoc
@@ -15,9 +15,9 @@ Content signing on {PrivateHubName} provides solutions for the following scenari
 
 . Log in to your {PrivateHubName} instance in the {HubName} UI.
 
-. In the left navigation, click *Collections > Approval*.
+. In the left navigation, click menu:Collections[Approval].
 The Approval dashboard is displayed with a list of collections.
 
-. Click the *Sign and approve* button for each collection you want to sign.
+. Click btn:[Sign and approve] for each collection you want to sign.
 
 . Verify that the collections you signed and approved manually are displayed in the Collections tab.

--- a/downstream/titles/hub/configuring-private-hub-rh-certified/master.adoc
+++ b/downstream/titles/hub/configuring-private-hub-rh-certified/master.adoc
@@ -21,7 +21,7 @@ include::hub/assembly-collections-and-content-signing-in-pah.adoc[leveloffset=+1
 When you complete all of the previous procedures, you will have:
 
 * created a synclist for Red Hat Certified collections content.
-* synced that content to your local {HubName}
+* synced that content to your local {HubName}.
 * designated community collections from {Galaxy} to distribute to your users.
 * configured content signing on {PrivateHubName}.
 * signed and approved collections for your organization's specific needs.

--- a/downstream/titles/hub/configuring-private-hub-rh-certified/master.adoc
+++ b/downstream/titles/hub/configuring-private-hub-rh-certified/master.adoc
@@ -8,6 +8,8 @@ You can sync {HubName} to use the Red Hat Certified Collections available throug
 
 Your organization can access and curate into a unique set of collections from all Red Hat Certified content in the {HubName} service hosted on console.redhat.com.
 
+You can also configure private automation hub for signing and publishing Ansible content collections tailored to meet your organization's unique needs.
+
 include::hub/assembly-synclists.adoc[leveloffset=+1]
 
 include::hub/assembly-syncing-to-cloud-repo.adoc[leveloffset=+1]

--- a/downstream/titles/hub/configuring-private-hub-rh-certified/master.adoc
+++ b/downstream/titles/hub/configuring-private-hub-rh-certified/master.adoc
@@ -4,11 +4,17 @@
 
 include::attributes/attributes.adoc[]
 
+<<<<<<< HEAD
 You can sync {HubName} to use the Red Hat Certified Collections available through your {PlatformNameShort} subscription or community collections available through {Galaxy}.
 
 Your organization can access and curate into a unique set of collections from all Red Hat Certified content in the {HubName} service hosted on console.redhat.com.
+=======
+You can sync {HubName} to use the Red Hat Certified Collections available through your {PlatformNameShort} subscription or community collections available through {Galaxy}. 
 
-You can also configure private automation hub for signing and publishing Ansible content collections tailored to meet your organization's unique needs.
+Your organization can access and curate into a unique set of collections from all Red Hat Certified content in the {HubName} service hosted on cloud.redhat.com.
+>>>>>>> effc5a0 (AAP-2844 Resolved conflict by adding attributes in intro)
+
+You can also configure private {HubName} for signing and publishing Ansible content collections tailored to meet your organization's unique needs.
 
 include::hub/assembly-synclists.adoc[leveloffset=+1]
 
@@ -18,10 +24,15 @@ include::hub/assembly-collections-and-content-signing-in-pah.adoc[leveloffset=+1
 
 == Conclusion
 
+<<<<<<< HEAD
 When the above procedures are complete, you will have:
 
 * created a synclist for Red Hat Certified collections content,
 * synced that content to your local {HubName}, and
 * designated community collections from {Galaxy} to distribute to your users.
 
+=======
+Upon completing the above procedures, you will have created a synclist for Red Hat Certified collections content, synced that content to your local {HubName}, and designated community collections from {Galaxy} to distribute to your users.
+
+>>>>>>> effc5a0 (AAP-2844 Resolved conflict by adding attributes in intro)
 Users can now view and download collections content from your local {HubName}.

--- a/downstream/titles/hub/configuring-private-hub-rh-certified/master.adoc
+++ b/downstream/titles/hub/configuring-private-hub-rh-certified/master.adoc
@@ -4,15 +4,9 @@
 
 include::attributes/attributes.adoc[]
 
-<<<<<<< HEAD
 You can sync {HubName} to use the Red Hat Certified Collections available through your {PlatformNameShort} subscription or community collections available through {Galaxy}.
 
 Your organization can access and curate into a unique set of collections from all Red Hat Certified content in the {HubName} service hosted on console.redhat.com.
-=======
-You can sync {HubName} to use the Red Hat Certified Collections available through your {PlatformNameShort} subscription or community collections available through {Galaxy}. 
-
-Your organization can access and curate into a unique set of collections from all Red Hat Certified content in the {HubName} service hosted on cloud.redhat.com.
->>>>>>> effc5a0 (AAP-2844 Resolved conflict by adding attributes in intro)
 
 You can also configure private {HubName} for signing and publishing Ansible content collections tailored to meet your organization's unique needs.
 
@@ -24,15 +18,10 @@ include::hub/assembly-collections-and-content-signing-in-pah.adoc[leveloffset=+1
 
 == Conclusion
 
-<<<<<<< HEAD
 When the above procedures are complete, you will have:
 
 * created a synclist for Red Hat Certified collections content,
 * synced that content to your local {HubName}, and
 * designated community collections from {Galaxy} to distribute to your users.
 
-=======
-Upon completing the above procedures, you will have created a synclist for Red Hat Certified collections content, synced that content to your local {HubName}, and designated community collections from {Galaxy} to distribute to your users.
-
->>>>>>> effc5a0 (AAP-2844 Resolved conflict by adding attributes in intro)
 Users can now view and download collections content from your local {HubName}.

--- a/downstream/titles/hub/configuring-private-hub-rh-certified/master.adoc
+++ b/downstream/titles/hub/configuring-private-hub-rh-certified/master.adoc
@@ -12,6 +12,8 @@ include::hub/assembly-synclists.adoc[leveloffset=+1]
 
 include::hub/assembly-syncing-to-cloud-repo.adoc[leveloffset=+1]
 
+include::hub/assembly-collections-and-content-signing-in-pah.adoc[leveloffset=+1]
+
 == Conclusion
 
 When the above procedures are complete, you will have:

--- a/downstream/titles/hub/configuring-private-hub-rh-certified/master.adoc
+++ b/downstream/titles/hub/configuring-private-hub-rh-certified/master.adoc
@@ -18,10 +18,13 @@ include::hub/assembly-collections-and-content-signing-in-pah.adoc[leveloffset=+1
 
 == Conclusion
 
-When the above procedures are complete, you will have:
+When you complete all of the previous procedures, you will have:
 
-* created a synclist for Red Hat Certified collections content,
-* synced that content to your local {HubName}, and
+* created a synclist for Red Hat Certified collections content.
+* synced that content to your local {HubName}
 * designated community collections from {Galaxy} to distribute to your users.
+* configured content signing on {PrivateHubName}.
+* signed and approved collections for your organization's specific needs.
+* configured Ansible-Galaxy CLI to verify collections before signing them.
 
 Users can now view and download collections content from your local {HubName}.


### PR DESCRIPTION
Adding collection and content signing topics to the Managing Red Hat Certified and Ansible Galaxy collections in Automation Hub guide:

Collections and content signing in private automation hub (Chapter 3)
Configuring content signing on private automation hub (Chapter 3.1)
Using content signing services in private automation hub (Chapter 3.2)
Configuring Ansible-Galaxy CLI to verify collections (Chapter 3.3)
Also, updated preface section to include a statement about collections in private automation hub so that the overall flow of the information is cohesive and Chapter 3 does not seem like it's simply thrown into the outline of topics.
Affects `titles/hub/configuring-private-hub-rh-certified`